### PR TITLE
Fixed Social Icons shape, and horizontal and vertical alignments (fixes #28340).

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -11,8 +11,10 @@
 	transform: none;
 }
 
+// Align social links vertically to Page-Links text when using vertical Navigation block.
 .editor-styles-wrapper .wp-block-social-links {
 	padding: 0;
+	padding-left: 0.5em;
 }
 
 // Placeholder/setup state.

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: flex-start;
+	align-items: center;
 	padding-left: 0;
 	padding-right: 0;
 	// Some themes set text-indent on all <ul>
@@ -90,7 +91,8 @@
 	@include reduce-motion("transition");
 
 	// Dimensions.
-	height: auto;
+	// Height value has to be fit-content otherwise the social icons will be oblong instead of circle when selecting Small or Normal Size in the Block Editor.
+	height: fit-content;
 
 	a {
 		display: block;


### PR DESCRIPTION
Original issue was that when adding Social Icons to a Navigation block, the icons would be oblong instead of circle. The icons only misshapened when size Small or Normal was selected. I also noticed that when a horizontal Nav block was added, the social icons wouldn't align horizontally, and in a vertical Nav block, the social icons wouldn't align vertically.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR. <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/native-mobile.md -->
